### PR TITLE
fix(core): add multi-block formatting support following the pattern

### DIFF
--- a/packages/core/src/headless/src/headless.ts
+++ b/packages/core/src/headless/src/headless.ts
@@ -123,38 +123,91 @@ export function insertTextAt(position: number, text: string): string {
 }
 
 /**
- * Toggles bold formatting on a range.
+ * Represents a selection range within a specific block.
  */
-export function toggleBold(start: number, end: number): string {
+export interface BlockSelection {
+  blockId: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Toggles bold formatting on a range.
+ * @param start - Start offset (used when selections is null)
+ * @param end - End offset (used when selections is null)
+ * @param selections - Optional array of block selections for multi-block formatting
+ */
+export function toggleBold(
+  start: number,
+  end: number,
+  selections?: BlockSelection[] | null
+): string {
   const service = new FormattingService(state);
-  service.toggleStyle(start, end, 'bold');
+  if (selections && selections.length > 0) {
+    service.toggleStyleForMultipleBlocks(selections, 'bold');
+  } else {
+    service.toggleStyle(start, end, 'bold');
+  }
   return getContentHtml();
 }
 
 /**
  * Toggles italic formatting on a range.
+ * @param start - Start offset (used when selections is null)
+ * @param end - End offset (used when selections is null)
+ * @param selections - Optional array of block selections for multi-block formatting
  */
-export function toggleItalic(start: number, end: number): string {
+export function toggleItalic(
+  start: number,
+  end: number,
+  selections?: BlockSelection[] | null
+): string {
   const service = new FormattingService(state);
-  service.toggleStyle(start, end, 'italic');
+  if (selections && selections.length > 0) {
+    service.toggleStyleForMultipleBlocks(selections, 'italic');
+  } else {
+    service.toggleStyle(start, end, 'italic');
+  }
   return getContentHtml();
 }
 
 /**
  * Toggles underline formatting on a range.
+ * @param start - Start offset (used when selections is null)
+ * @param end - End offset (used when selections is null)
+ * @param selections - Optional array of block selections for multi-block formatting
  */
-export function toggleUnderline(start: number, end: number): string {
+export function toggleUnderline(
+  start: number,
+  end: number,
+  selections?: BlockSelection[] | null
+): string {
   const service = new FormattingService(state);
-  service.toggleStyle(start, end, 'underline');
+  if (selections && selections.length > 0) {
+    service.toggleStyleForMultipleBlocks(selections, 'underline');
+  } else {
+    service.toggleStyle(start, end, 'underline');
+  }
   return getContentHtml();
 }
 
 /**
  * Toggles strikethrough formatting on a range.
+ * @param start - Start offset (used when selections is null)
+ * @param end - End offset (used when selections is null)
+ * @param selections - Optional array of block selections for multi-block formatting
  */
-export function toggleStrikethrough(start: number, end: number): string {
+export function toggleStrikethrough(
+  start: number,
+  end: number,
+  selections?: BlockSelection[] | null
+): string {
   const service = new FormattingService(state);
-  service.toggleStyle(start, end, 'strikethrough');
+  if (selections && selections.length > 0) {
+    service.toggleStyleForMultipleBlocks(selections, 'strikethrough');
+  } else {
+    service.toggleStyle(start, end, 'strikethrough');
+  }
   return getContentHtml();
 }
 

--- a/packages/core/src/headless/src/services/FormattingService.ts
+++ b/packages/core/src/headless/src/services/FormattingService.ts
@@ -1,5 +1,5 @@
 import HeadlessState from '../core/HeadlessState';
-import type { TextAttribute } from '../types';
+import type { TextAttribute, BlockSelection } from '../types';
 
 /**
  * Service for handling text formatting operations.
@@ -18,6 +18,28 @@ class FormattingService {
 
     const allActive = doc.isRangeEntirelyAttribute(start, end, attr);
     doc.formatAttribute(start, end, attr, !allActive);
+  }
+
+  /**
+   * Toggles a style attribute across multiple blocks.
+   * @param selections - Array of block selections with their ranges
+   * @param attr - The attribute to toggle
+   */
+  toggleStyleForMultipleBlocks(
+    selections: BlockSelection[],
+    attr: TextAttribute
+  ): void {
+    const doc = this.state.getDocument();
+    if (selections.length === 0) return;
+
+    // Check if all selections already have the attribute
+    const allActive = doc.isRangeEntirelyAttributeForMultipleBlocks(
+      selections,
+      attr
+    );
+
+    // Toggle: if all have attribute, remove it; otherwise, add it
+    doc.formatAttributeForMultipleBlocks(selections, attr, !allActive);
   }
 
   /**

--- a/packages/core/src/headless/src/types/index.ts
+++ b/packages/core/src/headless/src/types/index.ts
@@ -2,6 +2,16 @@ export type TextAttribute = 'bold' | 'italic' | 'underline' | 'strikethrough';
 export type BlockType = 'text' | 'image';
 export type Alignment = 'left' | 'center' | 'right' | 'justify';
 
+/**
+ * Represents a selection range within a specific block.
+ * Used for multi-block formatting operations.
+ */
+export interface BlockSelection {
+  blockId: string;
+  start: number;
+  end: number;
+}
+
 export interface PieceAttributes {
   bold?: boolean;
   italic?: boolean;


### PR DESCRIPTION
# Description

Added multi-block formatting support following the pattern of toggleOrderedListForMultipleBlocks.                                                                        
The caller needs to compute the BlockSelection array from the DOM selection when the user selects text across multiple blocks.

Closes #231 

# All TextIgniterJS Contribution checklist:

- [x] **The pull request does not introduce [breaking changes].**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
